### PR TITLE
Changing PREFIX to CONDA_PREFIX in post-link and pre-unlink

### DIFF
--- a/iraf.adccdrom/meta.yaml
+++ b/iraf.adccdrom/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: ADCCDROM package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:
@@ -22,4 +22,3 @@ requirements:
     - iraf !=2.16.1,>=2.16.UR
     run:
     - iraf !=2.16.1,>=2.16.UR
-

--- a/iraf.adccdrom/post-link.sh
+++ b/iraf.adccdrom/post-link.sh
@@ -1,4 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" adccdrom
-
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" adccdrom

--- a/iraf.adccdrom/pre-unlink.sh
+++ b/iraf.adccdrom/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove adccdrom  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove adccdrom  2>/dev/null; :

--- a/iraf.cfh12k/meta.yaml
+++ b/iraf.cfh12k/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: CFH12K package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.cfh12k/post-link.sh
+++ b/iraf.cfh12k/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" cfh12k
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" cfh12k

--- a/iraf.cfh12k/pre-unlink.sh
+++ b/iraf.cfh12k/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove cfh12k  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove cfh12k  2>/dev/null; :

--- a/iraf.cirred/meta.yaml
+++ b/iraf.cirred/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: CIRRED package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:
@@ -25,4 +25,3 @@ requirements:
     run:
     - iraf !=2.16.1,>=2.16.UR
     - iraf.stsdas
-

--- a/iraf.cirred/post-link.sh
+++ b/iraf.cirred/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" cirred
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" cirred

--- a/iraf.cirred/pre-unlink.sh
+++ b/iraf.cirred/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove cirred  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove cirred  2>/dev/null; :

--- a/iraf.ctio/meta.yaml
+++ b/iraf.ctio/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: CTIO package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.ctio/post-link.sh
+++ b/iraf.ctio/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" ctio
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" ctio

--- a/iraf.ctio/pre-unlink.sh
+++ b/iraf.ctio/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove ctio  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove ctio  2>/dev/null; :

--- a/iraf.cutoutpkg/meta.yaml
+++ b/iraf.cutoutpkg/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: CUTOUTPKG package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.cutoutpkg/post-link.sh
+++ b/iraf.cutoutpkg/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" cutoutpkg
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" cutoutpkg

--- a/iraf.cutoutpkg/pre-unlink.sh
+++ b/iraf.cutoutpkg/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove cutoutpkg  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove cutoutpkg  2>/dev/null; :

--- a/iraf.deitab/meta.yaml
+++ b/iraf.deitab/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: DEITAB package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:
@@ -24,4 +24,3 @@ requirements:
     run:
     - iraf !=2.16.1,>=2.16.UR
     - iraf.tables
-

--- a/iraf.deitab/post-link.sh
+++ b/iraf.deitab/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" deitab
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" deitab

--- a/iraf.deitab/pre-unlink.sh
+++ b/iraf.deitab/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove deitab  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove deitab  2>/dev/null; :

--- a/iraf.esowfi/meta.yaml
+++ b/iraf.esowfi/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: ESOWFI package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:
@@ -23,4 +23,3 @@ requirements:
     run:
     - iraf !=2.16.1,>=2.16.UR
     - iraf.mscred
-

--- a/iraf.esowfi/post-link.sh
+++ b/iraf.esowfi/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" esowfi
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" esowfi

--- a/iraf.esowfi/pre-unlink.sh
+++ b/iraf.esowfi/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove esowfi  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove esowfi  2>/dev/null; :

--- a/iraf.finder/meta.yaml
+++ b/iraf.finder/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: FINDER package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.finder/post-link.sh
+++ b/iraf.finder/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" finder
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" finder

--- a/iraf.finder/pre-unlink.sh
+++ b/iraf.finder/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove finder  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove finder  2>/dev/null; :

--- a/iraf.fitsutil/meta.yaml
+++ b/iraf.fitsutil/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: FITSUTIL package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, as conda unhelpfully
     # disallows the post-install step from depending on other packages:
     always_include_files:
@@ -24,4 +24,3 @@ requirements:
     - iraf !=2.16.1,>=2.16.UR
     run:
     - iraf !=2.16.1,>=2.16.UR  # (must ensure correct run-time "iraf" version)
-

--- a/iraf.fitsutil/post-link.sh
+++ b/iraf.fitsutil/post-link.sh
@@ -1,4 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" fitsutil
-
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" fitsutil

--- a/iraf.fitsutil/pre-unlink.sh
+++ b/iraf.fitsutil/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove fitsutil  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove fitsutil  2>/dev/null; :

--- a/iraf.gemini/meta.yaml
+++ b/iraf.gemini/meta.yaml
@@ -5,7 +5,7 @@ about:
     summary: Gemini IRAF package
 build:
     binary_relocation: False
-    number: '0'
+    number: '1'
     # These must be copied from astroconda-iraf-helpers, as conda unhelpfully
     # disallows the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.gemini/post-link.sh
+++ b/iraf.gemini/post-link.sh
@@ -1,4 +1,4 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" gemini
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" gemini
 

--- a/iraf.gemini/pre-unlink.sh
+++ b/iraf.gemini/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove gemini  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove gemini  2>/dev/null; :

--- a/iraf.gmisc/meta.yaml
+++ b/iraf.gmisc/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: GMISC package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.gmisc/post-link.sh
+++ b/iraf.gmisc/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" gmisc
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" gmisc

--- a/iraf.gmisc/pre-unlink.sh
+++ b/iraf.gmisc/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove gmisc  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove gmisc  2>/dev/null; :

--- a/iraf.guiapps/meta.yaml
+++ b/iraf.guiapps/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: GUIAPPS package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.guiapps/post-link.sh
+++ b/iraf.guiapps/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" guiapps
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" guiapps

--- a/iraf.guiapps/pre-unlink.sh
+++ b/iraf.guiapps/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove guiapps  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove guiapps  2>/dev/null; :

--- a/iraf.mem0/meta.yaml
+++ b/iraf.mem0/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: MEM0 package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.mem0/post-link.sh
+++ b/iraf.mem0/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" mem0
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" mem0

--- a/iraf.mem0/pre-unlink.sh
+++ b/iraf.mem0/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove mem0  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove mem0  2>/dev/null; :

--- a/iraf.mscdb/meta.yaml
+++ b/iraf.mscdb/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: MSCDB package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.mscdb/post-link.sh
+++ b/iraf.mscdb/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" mscdb
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" mscdb

--- a/iraf.mscdb/pre-unlink.sh
+++ b/iraf.mscdb/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove mscdb  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove mscdb  2>/dev/null; :

--- a/iraf.mscred/meta.yaml
+++ b/iraf.mscred/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: MSCRED package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.mscred/post-link.sh
+++ b/iraf.mscred/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" mscred
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" mscred

--- a/iraf.mscred/pre-unlink.sh
+++ b/iraf.mscred/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove mscred  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove mscred  2>/dev/null; :

--- a/iraf.mtools/meta.yaml
+++ b/iraf.mtools/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: MTOOLS package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.mtools/post-link.sh
+++ b/iraf.mtools/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" mtools
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" mtools

--- a/iraf.mtools/pre-unlink.sh
+++ b/iraf.mtools/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove mtools  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove mtools  2>/dev/null; :

--- a/iraf.nfextern/meta.yaml
+++ b/iraf.nfextern/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: NFEXTERN package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.nfextern/post-link.sh
+++ b/iraf.nfextern/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" nfextern
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" nfextern

--- a/iraf.nfextern/pre-unlink.sh
+++ b/iraf.nfextern/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove nfextern  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove nfextern  2>/dev/null; :

--- a/iraf.optic/meta.yaml
+++ b/iraf.optic/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: OPTIC package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:
@@ -23,4 +23,3 @@ requirements:
     run:
     - iraf !=2.16.1,>=2.16.UR
     - iraf.mscred
-

--- a/iraf.optic/post-link.sh
+++ b/iraf.optic/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" optic
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" optic

--- a/iraf.optic/pre-unlink.sh
+++ b/iraf.optic/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove optic  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove optic  2>/dev/null; :

--- a/iraf.rvsao/meta.yaml
+++ b/iraf.rvsao/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: RVSAO package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.rvsao/post-link.sh
+++ b/iraf.rvsao/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" rvsao
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" rvsao

--- a/iraf.rvsao/pre-unlink.sh
+++ b/iraf.rvsao/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove rvsao  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove rvsao  2>/dev/null; :

--- a/iraf.song/meta.yaml
+++ b/iraf.song/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: SONG package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.song/post-link.sh
+++ b/iraf.song/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" song
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" song

--- a/iraf.song/pre-unlink.sh
+++ b/iraf.song/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove song  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove song  2>/dev/null; :

--- a/iraf.sqiid/meta.yaml
+++ b/iraf.sqiid/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: SQIID package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.sqiid/post-link.sh
+++ b/iraf.sqiid/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" sqiid
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" sqiid

--- a/iraf.sqiid/pre-unlink.sh
+++ b/iraf.sqiid/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove sqiid  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove sqiid  2>/dev/null; :

--- a/iraf.stecf/meta.yaml
+++ b/iraf.stecf/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: STECF package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda unhelpfully
     # disallows the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.stecf/post-link.sh
+++ b/iraf.stecf/post-link.sh
@@ -1,4 +1,4 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" stecf
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" stecf
 

--- a/iraf.stecf/pre-unlink.sh
+++ b/iraf.stecf/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove stecf  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove stecf  2>/dev/null; :

--- a/iraf.stsdas/meta.yaml
+++ b/iraf.stsdas/meta.yaml
@@ -5,7 +5,7 @@ about:
 build:
     binary_relocation: False
     detect_binary_files_with_prefix: False
-    number: '0'
+    number: '1'
     # These must be copied from astroconda-iraf-helpers, as conda unhelpfully
     # disallows the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.stsdas/post-link.sh
+++ b/iraf.stsdas/post-link.sh
@@ -1,4 +1,4 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" stsdas
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" stsdas
 

--- a/iraf.stsdas/pre-unlink.sh
+++ b/iraf.stsdas/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove stsdas  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove stsdas  2>/dev/null; :

--- a/iraf.tables/meta.yaml
+++ b/iraf.tables/meta.yaml
@@ -5,7 +5,7 @@ about:
 build:
     binary_relocation: False
     detect_binary_files_with_prefix: False
-    number: '0'
+    number: '1'
     # These must be copied from astroconda-iraf-helpers, as conda unhelpfully
     # disallows the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.tables/post-link.sh
+++ b/iraf.tables/post-link.sh
@@ -1,4 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" tables
-
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" tables

--- a/iraf.tables/pre-unlink.sh
+++ b/iraf.tables/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove tables  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove tables  2>/dev/null; :

--- a/iraf.ucsclris/meta.yaml
+++ b/iraf.ucsclris/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: UCSCLRIS package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:
@@ -23,4 +23,3 @@ requirements:
     run:
     - iraf !=2.16.1,>=2.16.UR
     - iraf.stsdas  # used only by prep.qmask_plot
-

--- a/iraf.ucsclris/post-link.sh
+++ b/iraf.ucsclris/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" ucsclris
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" ucsclris

--- a/iraf.ucsclris/pre-unlink.sh
+++ b/iraf.ucsclris/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove ucsclris  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove ucsclris  2>/dev/null; :

--- a/iraf.upsqiid/meta.yaml
+++ b/iraf.upsqiid/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: UPSQIID package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:
@@ -24,4 +24,3 @@ requirements:
     - iraf !=2.16.1,>=2.16.UR
     run:
     - iraf !=2.16.1,>=2.16.UR
-

--- a/iraf.upsqiid/post-link.sh
+++ b/iraf.upsqiid/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" upsqiid
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" upsqiid

--- a/iraf.upsqiid/pre-unlink.sh
+++ b/iraf.upsqiid/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove upsqiid  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove upsqiid  2>/dev/null; :

--- a/iraf.xdimsum/meta.yaml
+++ b/iraf.xdimsum/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: XDIMSUM package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:
@@ -24,4 +24,3 @@ requirements:
     - iraf !=2.16.1,>=2.16.UR
     # One task also uses STSDAS but it lives in the "obsolete" dir, so don't
     # pull in all of STSDAS just for that (unless user installs it manually).
-

--- a/iraf.xdimsum/post-link.sh
+++ b/iraf.xdimsum/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" xdimsum
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" xdimsum

--- a/iraf.xdimsum/pre-unlink.sh
+++ b/iraf.xdimsum/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove xdimsum  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove xdimsum  2>/dev/null; :

--- a/iraf.xray/meta.yaml
+++ b/iraf.xray/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: XRAY package for IRAF
 build:
     binary_relocation: False
-    number: '1'
+    number: '2'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/iraf.xray/post-link.sh
+++ b/iraf.xray/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" xray
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" xray

--- a/iraf.xray/pre-unlink.sh
+++ b/iraf.xray/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove xray  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove xray  2>/dev/null; :

--- a/pyfu/meta.yaml
+++ b/pyfu/meta.yaml
@@ -4,7 +4,7 @@ about:
     license_file: LICENSE
     summary: IFU datacube mosaicking package for PyRAF and Python
 build:
-    number: '0'
+    number: '1'
     # These must be copied from astroconda-iraf-helpers, as conda unhelpfully
     # disallows the post-install step from depending on other packages:
     always_include_files:
@@ -28,4 +28,3 @@ requirements:
     # PyRAF is an optional dependency if the IRAF interface is used but is not
     # needed by the Python interface so don't require it here, as that would
     # also drag in IRAF etc.
-

--- a/pyfu/post-link.sh
+++ b/pyfu/post-link.sh
@@ -1,4 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" pyfu
-
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" pyfu

--- a/pyfu/pre-unlink.sh
+++ b/pyfu/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove pyfu  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove pyfu  2>/dev/null; :

--- a/pyraf.kepler/meta.yaml
+++ b/pyraf.kepler/meta.yaml
@@ -4,7 +4,7 @@ about:
     summary: A suite of Python/PyRAF tools to analyze Kepler data
 build:
     binary_relocation: False
-    number: '0'
+    number: '1'
     # These must be copied from astroconda-iraf-helpers, since conda disallows
     # the post-install step from depending on other packages:
     always_include_files:

--- a/pyraf.kepler/post-link.sh
+++ b/pyraf.kepler/post-link.sh
@@ -1,3 +1,3 @@
 # Call a common script that updates extern.pkg for the new IRAF package:
 
-"$PREFIX/bin/ac_config_iraf_pkg" kepler
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" kepler

--- a/pyraf.kepler/pre-unlink.sh
+++ b/pyraf.kepler/pre-unlink.sh
@@ -1,1 +1,1 @@
-"$PREFIX/bin/ac_config_iraf_pkg" --remove kepler  2>/dev/null; :
+"$CONDA_PREFIX/bin/ac_config_iraf_pkg" --remove kepler  2>/dev/null; :


### PR DESCRIPTION
Conda uses `$PREFIX` variable only for building. For the env prefix, it's mandatory to use `$CONDA_PREFIX` variable. After Anaconda 5.2, all the IRAF packages with pre-unlink.sh and post-link.sh will install using `$PREFIX` variable.

So, I changed all this scripts to install properly now.

Possible solution for #4 issue.